### PR TITLE
add serena + cocoindex-code MCPs, sync Codex, track mcp.json in dotfiles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,4 +18,10 @@ Hard rules:
 - Use `worktrunk` / `wt` for worktrees, never `superpowers:using-git-worktrees`.
 - Spawn agent teams via `TeamCreate → TaskCreate → Agent(team_name)`; never `cmux claude-teams`, never bare `Agent(run_in_background=true)`.
 
+MCP config layout (all tracked in dotfiles via links.tsv):
+
+- `~/.claude/mcp.json` → `dotfiles/.claude/mcp.json` — Claude Code user-level MCP servers (serena, cocoindex-code, parallel-search)
+- `~/.codex/config.toml` → `dotfiles/.codex/config.toml` — Codex MCP servers (same local MCPs + Runlayer remotes)
+- `~/.claude/settings.json` and `~/.claude.json` are also symlinked; `mcpServers` is NOT valid in settings files — use `mcp.json` only.
+
 @RTK.md

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "serena",
+      "args": ["start-mcp-server", "--context", "claude-code", "--project-from-cwd"]
+    },
+    "cocoindex-code": {
+      "type": "stdio",
+      "command": "ccc",
+      "args": ["mcp"]
+    },
+    "parallel-search": {
+      "type": "stdio",
+      "command": "/Users/dataders/Developer/dotfiles/mcp/parallel-search/run.sh",
+      "args": []
+    }
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -97,6 +97,23 @@ url = "https://dbt.runlayer.com/api/v1/proxy/ab3aadc4-d6ac-4d92-85d6-cfba5eafc0e
 [mcp_servers.google-sheets]
 url = "https://dbt.runlayer.com/api/v1/proxy/ab3aadc4-d6ac-4d92-85d6-cfba5eafc0e1/mcp"
 
+# Local stdio MCPs — scripts live in dotfiles/mcp/.
+[mcp_servers.serena]
+command = "serena"
+args = ["start-mcp-server", "--context=codex", "--project-from-cwd"]
+
+[mcp_servers.cocoindex-code]
+command = "ccc"
+args = ["mcp"]
+
+[mcp_servers.community-slack]
+command = "/Users/dataders/Developer/dotfiles/mcp/community-slack/run.sh"
+args = []
+
+[mcp_servers.parallel-search]
+command = "/Users/dataders/Developer/dotfiles/mcp/parallel-search/run.sh"
+args = []
+
 [projects]
 # Trust the repo parent rather than every repo individually. Avoid trusting all
 # of /Users/dataders because home contains secrets and app state outside dev work.

--- a/links.tsv
+++ b/links.tsv
@@ -33,6 +33,7 @@ repo:.claude/settings.json	home:.claude/settings.json	agents	public	Claude share
 repo:.claude/settings.local.json	home:.claude/settings.local.json	agents	public	Claude local settings tracked here
 repo:.claude/statusline.sh	home:.claude/statusline.sh	agents	public	Claude statusline
 repo:.claude/CLAUDE.md	home:.claude/CLAUDE.md	agents	public	Claude global instructions
+repo:.claude/mcp.json	home:.claude/mcp.json	agents	public	Claude MCP server definitions
 repo:.claude.json	home:.claude.json	agents	public	Claude desktop config
 repo:.codex/config.toml	home:.codex/config.toml	agents	public	Codex config
 repo:.codex/hooks.json	home:.codex/hooks.json	agents	public	Codex hooks config


### PR DESCRIPTION
## Summary

- Add **serena** (LSP semantic nav) and **cocoindex-code** (AST search) as user-level MCPs for both Claude Code and Codex
- Sync Codex with local MCPs previously only in Claude Code: `community-slack`, `parallel-search`
- Bring `~/.claude/mcp.json` into dotfiles tracking via `links.tsv` (MCPs live here, not in `settings.json`)
- Document MCP config layout in `CLAUDE.md`

## Files changed

- `.claude/mcp.json` — new file; Claude Code user-level MCPs (serena, cocoindex-code, parallel-search)
- `.codex/config.toml` — adds serena, cocoindex-code, community-slack, parallel-search
- `links.tsv` — adds symlink entry for `.claude/mcp.json`
- `.claude/CLAUDE.md` — documents MCP config layout

## Post-merge

Run `./links.sh` to activate the `~/.claude/mcp.json` symlink.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)