### PR TITLE
wizard: fix MCP config load (rmcp flag + dbt server rename)

### DIFF
--- a/wizard/config.toml
+++ b/wizard/config.toml
@@ -1,5 +1,8 @@
 model = "openai_subscription/gpt-5.5"
 model_reasoning_effort = "medium"
+# Enable rmcp client so url-based (streamable_http) MCP servers load; older
+# Codex-fork parser otherwise treats every mcp_server as stdio and rejects url.
+experimental_use_rmcp_client = true
 [projects."/Users/dataders/Developer/internal-analytics"]
 trust_level = "trusted"
 

--- a/wizard/config.toml
+++ b/wizard/config.toml
@@ -41,7 +41,7 @@ url = "https://dbt.runlayer.com/api/v1/proxy/24736211-1060-47e7-897e-fdf5a531a3d
 [mcp_servers.slack]
 url = "https://dbt.runlayer.com/api/v1/proxy/dcf3b868-a852-4758-97aa-024fb941a173/mcp"
 
-[mcp_servers.dbt]
+[mcp_servers.dbt-runlayer]
 url = "https://dbt.runlayer.com/api/v1/proxy/404ba041-4eb4-4e29-a474-ae38e7899ac9/mcp"
 
 [mcp_servers.grep]


### PR DESCRIPTION
## Problem

`wizard` failed to load `config.toml` with:

```
Error loading config.toml: url is not supported for stdio in `mcp_servers.dbt`
```

Two root causes, both introduced by the wizard-config-consolidation work (#17) that mirrored Codex's `url`-based MCP servers into `wizard/config.toml`:

1. **dbt-wizard is a Codex fork whose default MCP client is stdio-only** and rejects the `url` field on `mcp_servers.*`. (Codex 0.135.0 supports `url` natively; the fork needs the rmcp client.)
2. **Server-name collision.** Wizard merges a project-local `.mcp.json` over the global config by server name. dbt projects (e.g. `internal-analytics`) define their own stdio `dbt` server (`uvx dbt-mcp`); the new global url-based `dbt` collided with it, merging into a stdio entry that still carried a `url` — the exact error above. This only surfaced inside a project dir, which is why `doctor` looked fine from neutral cwds.

## Fix

- Add `experimental_use_rmcp_client = true` so the streamable_http (`url`) servers load.
- Rename the global `dbt` Runlayer server to `dbt-runlayer` (matching the existing `notion-runlayer`/`runlayer-docs` convention) so it coexists with project-local stdio `dbt`.

## Verification

From `~/Developer/internal-analytics` (the original failing context):

```
wizard doctor  →  ✓ config loaded · 13 server (5 stdio, 8 streamable_http) · 0 disabled
wizard mcp list →  lists both `dbt` (stdio, uvx dbt-mcp) and `dbt-runlayer` (url), no error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)