### PR TITLE
drop cmux claude-teams wrapper from zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -148,20 +148,6 @@ export PATH="$PATH:/Users/dataders/.local/bin"
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 
-# Route claude through cmux claude-teams when inside cmux.
-# cmux claude-teams creates a tmux server socket at /tmp/cmux-claude-teams/UUID and sets $TMUX
-# to point to it — Claude Code needs $TMUX to spawn background agents as new panes
-# (teammateMode: "tmux" in settings.json). Without this, agent teams silently run as
-# local processes with no visible panes. The $TMUX guard prevents recursion: agent
-# panes spawned by Claude Code inherit the cmux-claude-teams socket path, so they
-# fall through to `command claude` directly.
-claude() {
-  if [[ -n "$CMUX_SURFACE_ID" && "$TMUX" != /tmp/cmux-claude-teams/* ]]; then
-    cmux claude-teams "$@"
-  else
-    command claude "$@"
-  fi
-}
 
 # Auto-name cmux tabs and color workspaces on directory change or branch switch.
 # Tab name: "repo · branch". Workspace color: looked up from _CMUX_REPO_COLORS.

--- a/.zshrc
+++ b/.zshrc
@@ -132,7 +132,7 @@ brew() {
     case "$1" in
         install|uninstall|remove|rm|upgrade|tap|untap)
             command brew bundle dump --file=~/Developer/dotfiles/Brewfile --force
-            ;;&
+            ;|
         install|upgrade)
             local _fsh_dir=/opt/homebrew/opt/zsh-fast-syntax-highlighting/share/zsh-fast-syntax-highlighting
             [[ -f "$_fsh_dir/fast-highlight" ]] && zcompile "$_fsh_dir/fast-highlight" "$_fsh_dir/fast-string-highlight"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,4 @@ herdr pane run "$NEW" "your task prompt here"
 
 Re-read pane IDs from `herdr pane list` rather than assuming they are stable.
 
-### Inside cmux
-The `claude()` wrapper in `.zshrc` auto-routes through `cmux claude-teams` when inside cmux,
-with a recursion guard so subagents fall through to `command claude` directly. Don't manually
-call `cmux claude-teams` or `cmux new-workspace` (creates a plain terminal, not a teammate).
-With cmux, `teammateMode: "tmux"` works and teammates get their own panes automatically.
-
 @RTK.md


### PR DESCRIPTION
## Summary
- Remove the `cmux claude-teams` wrapper from zshrc (agent teams are spawned via `TeamCreate → TaskCreate → Agent`, not the cmux wrapper)
- Fix zsh parse error in the `brew()` case statement: `;;&` → `;|`

## Commits
- `991a2e3` drop cmux claude-teams wrapper from zshrc
- `4d4feb0` fix zsh parse error: ;;& → ;| in brew() case

🤖 Generated with [Claude Code](https://claude.com/claude-code)