### PR TITLE
conductor: repo settings + fs spotlight-testing config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,6 +11,9 @@ Hard rules:
   `~/Developer/dotfiles_env`.
 - Use `links.tsv` plus `./links.sh dry-run`, `./links.sh check`, and
   `./links.sh doctor` for symlink work.
+- Never run `./links.sh apply` from a worktree / Conductor workspace — it
+  repoints `~` symlinks into the throwaway checkout and breaks them on archive.
+  Apply only from the primary checkout `~/Developer/dotfiles`.
 - Do not delete critical `~/.dbt/*` symlinks.
 - Use explicit overlay hooks only: `secrets.zsh`, `local.zsh`,
   `gitconfig.local`, and `source_dotfiles_env`.

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,53 @@
+# Conductor repository settings — github.com/dataders/dotfiles
+# Schema: https://conductor.build/schemas/settings.repo.schema.json
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Intentionally minimal. Everything Conductor's agents need is already defined
+# in config that Conductor discovers on its own. This file only holds settings
+# that are (a) specific to THIS repo and (b) NOT discoverable elsewhere.
+#
+# Deliberately EXCLUDED, and where Conductor already finds it:
+#
+#   Agent instructions / rules ....... AGENTS.md + .claude/CLAUDE.md (read by the
+#                                      Claude Code / Codex agent directly). So no
+#                                      [prompts] section — it would duplicate them.
+#
+#   MCP servers ...................... ~/.claude/mcp.json (Claude) and
+#                                      ~/.codex/config.toml (Codex), both symlinked
+#                                      from this repo and user-level → inherited.
+#
+#   Agent teams (TeamCreate→…) ....... CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 set in
+#                                      ~/.claude/settings.json AND ~/.codex/config.toml,
+#                                      both discovered. No env var needed here.
+#
+#   uv / rtk enforcement hooks ....... ~/.claude/hooks/*.sh, symlinked & user-level →
+#                                      apply to Conductor's Claude agents automatically.
+#
+#   claude / codex executables ....... codex is on PATH (/opt/homebrew/bin/codex);
+#                                      Conductor launches Claude Code via its own
+#                                      integration, NOT the .zshrc claude() cmux wrapper,
+#                                      so no executable_path override is needed.
+#
+#   [scripts] setup/run .............. This is a config repo with no build and no
+#                                      long-running dev server. The only "dev loop" is
+#                                      `uv run python3 -m unittest discover -s tests`,
+#                                      which is fine to run by hand. No setup/run script
+#                                      earns its keep — and a setup script must NEVER run
+#                                      `links.sh apply` (see AGENTS.md: it would repoint
+#                                      your ~ symlinks into the throwaway worktree).
+#
+#   secrets (dotfiles_env) ........... .databrickscfg / bigquery-service-key.json are
+#                                      tracked git symlinks → every workspace inherits
+#                                      them. No [file_include_globs] / .worktreeinclude
+#                                      needed.
+#
+# Generic, cross-repo Conductor behavior (model defaults, reasoning, tool approvals,
+# workspace location) is NOT repo-configurable — it lives in ~/.conductor/settings.toml.
+#
+# --- Optional Conductor-only workflow prefs (uncomment to opt in) ---------------
+# These ARE genuinely Conductor-only (no other tool defines them). Left off so the
+# file asserts no behavior you haven't chosen.
+#
+# [git]
+# delete_branch_on_archive = true   # tidy branches when archiving a workspace
+# archive_on_merge = true           # auto-archive a workspace once its PR merges

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Bare `pip`, `pip3`, and `python3` invocations are blocked by a PreToolUse hook. 
 - **Public configs**: `~/Developer/dotfiles` (git-tracked, GitHub)
 - **Private/secrets**: `~/Developer/dotfiles_env` (local only, not pushed)
 - Symlinks managed by: `links.tsv` plus `links.sh`; use `./links.sh dry-run`, `./links.sh check`, and `./links.sh doctor` before/after link changes.
+- **Never run `./links.sh apply` from a worktree or Conductor workspace.** `links.sh` derives its repo root from the script's own location, so applying from a throwaway worktree repoints your `~` symlinks (`.zshrc`, `.gitconfig`, MCP configs, etc.) into that worktree — they break when the worktree is archived. Run `apply` only from the primary checkout `~/Developer/dotfiles`. From a worktree, `dry-run`/`check`/`doctor` (read-only) are fine.
 - Overlay hooks are explicit only: `.zshrc` may source `dotfiles_env/secrets.zsh` and `dotfiles_env/local.zsh`; `.gitconfig` may include `dotfiles_env/gitconfig.local`; direnv projects may call `source_dotfiles_env`. Do not add profile flags or broad auto-discovery.
 - **Critical symlinks in `~/.dbt/`** point to `~/Developer/dotfiles_env/.dbt/` (profiles.yml, dbt_cloud.yml, mcp.yml, keyfile.json, .user.yml). **Do NOT delete these symlinks.** If you must remove one for testing, restore it immediately when done (e.g. `ln -sf ~/Developer/dotfiles_env/.dbt/dbt_cloud.yml ~/.dbt/dbt_cloud.yml`).
 

--- a/links.tsv
+++ b/links.tsv
@@ -56,6 +56,7 @@ env:.dbt/mcp.yml	home:.dbt/mcp.yml	dbt	private	dbt MCP config
 env:.dbt/keyfile.json	home:.dbt/keyfile.json	dbt	private	dbt keyfile
 env:.dbt/.user.yml	home:.dbt/.user.yml	dbt	private	dbt user state
 repo:workspaces/fs/settings.json	developer:fs/.vscode/settings.json	editor	public	fs workspace settings
+repo:workspaces/fs/conductor.toml	developer:fs/.conductor/settings.local.toml	agents	public	fs Conductor spotlight-testing config
 repo:workspaces/internal-analytics/settings.json	developer:internal-analytics/.vscode/settings.json	editor	public	internal analytics workspace settings
 repo:workspaces/jaffle-sandbox/settings.json	developer:jaffle-sandbox/.vscode/settings.json	editor	public	jaffle sandbox workspace settings
 repo:wizard/config.toml	home:.dbt/wizard/config.toml	agents	public	Wizard general config (Codex schema)

--- a/workspaces/fs/conductor.toml
+++ b/workspaces/fs/conductor.toml
@@ -1,0 +1,17 @@
+# Conductor settings for the fs (dbt-fusion) repo.
+# Stored here in dotfiles, symlinked to ~/Developer/fs/.conductor/settings.local.toml
+# via links.tsv (group: agents). Named *.local.toml at the target so Conductor
+# treats it as PERSONAL repo settings and fs's git ignores it (.git/info/exclude) —
+# it is never committed to the shared fs repo, and the symlink never leaks to teammates.
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# fs is a large Rust workspace. `cargo xtask test` is the only supported full-suite
+# run (per fs README), and the debug/release target/ is multi-GB and slow to build.
+# Spotlight testing runs the suite from the repo ROOT — one shared target/ and one
+# nextest cache — while agents keep editing in their own Conductor workspaces, instead
+# of every workspace compiling its own target/ from scratch.
+spotlight_testing = true
+
+[scripts]
+run = "cargo xtask test"      # fs README: the only supported way to run the full suite
+run_mode = "nonconcurrent"    # single shared root build/target — don't run in parallel


### PR DESCRIPTION
## What

- **`.conductor/settings.toml`** — minimal Conductor repo settings for dotfiles. Deliberately near-empty: documents what Conductor already discovers (`AGENTS.md`/`CLAUDE.md`, `~/.claude/mcp.json`, `~/.codex/config.toml`, hooks) so nothing is duplicated. No `[scripts]`/`[prompts]` — a config repo has no dev loop, and prompts would just re-state AGENTS.md.
- **`workspaces/fs/conductor.toml`** — fs (dbt-fusion) Conductor settings: `spotlight_testing = true`, `run = "cargo xtask test"`, `run_mode = "nonconcurrent"`. Symlinked into fs as `.conductor/settings.local.toml` (personal, gitignored locally in fs — never committed to the shared repo). Spotlight runs the heavy Rust suite from the fs root (one shared `target/` + nextest cache) while agents edit in separate workspaces.
- **`links.tsv`** — manage the fs conductor symlink (mirrors the existing `developer:fs/.vscode/settings.json` pattern).
- **`AGENTS.md` + `.claude/CLAUDE.md`** — guardrail: never run `./links.sh apply` from a worktree/Conductor workspace; it repoints `~` symlinks into the throwaway checkout and breaks them on archive. Apply only from the primary checkout.

## After merge

Run from the **primary** checkout (not a worktree):
\`\`\`
cd ~/Developer/dotfiles && git fetch && git merge --ff-only origin/main && ./links.sh apply
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)