### PR TITLE
zshrc: add gcloud CLI to PATH

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -20,6 +20,7 @@ path_additions=(
     "/opt/homebrew/opt/openjdk@17/bin"           # OpenJDK 17
     "$HOME/.wasmtime/bin"                        # Wasmtime
     "$HOME/.codeium/windsurf/bin"                # Windsurf
+    "/opt/homebrew/share/google-cloud-sdk/bin"   # gcloud CLI
     "$HOME/.local/bin"                           # dbt Cloud CLI, local scripts
 )
 


### PR DESCRIPTION
Add `/opt/homebrew/share/google-cloud-sdk/bin` to `path_additions` so the gcloud CLI is available in interactive shells.

Opened automatically while cleaning up the `gcloud-path` worktree so the commit isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)