### PR TITLE
Add GitHub notification sweep

### DIFF
--- a/Library/LaunchAgents/com.dataders.github-notification-sweep.plist
+++ b/Library/LaunchAgents/com.dataders.github-notification-sweep.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dataders.github-notification-sweep</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/dataders/Developer/dotfiles/bin/github-notification-sweep</string>
+        <string>--apply</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.dataders.github-notification-sweep.err.log</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.dataders.github-notification-sweep.out.log</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ when deciding whether a config belongs in this public repo or in
 | Git hooks | `.githooks/pre-commit` | repo-local `core.hooksPath` | Blocks likely-sensitive paths and TruffleHog findings in staged diff |
 | Direnv | `.config/direnv/direnvrc` | `~/.config/direnv/direnvrc` | Defines `source_dotfiles_env` for private per-project env overlays |
 | GitHub CLI | `.config/gh/hosts.yml` | `~/.config/gh/hosts.yml` | Auth host config, symlinked through `links.sh` |
+| GitHub notification sweep | `bin/github-notification-sweep`, `Library/LaunchAgents/com.dataders.github-notification-sweep.plist` | `~/Library/LaunchAgents/...` | Local launchd job marks stale CI notifications done when PR merged or head moved |
 | Codex | `.codex/config.toml`, `.codex/AGENTS.md`, `.codex/RTK.md`, `.codex/rules/default.rules` | `~/.codex/...` | Model, sandbox, MCP servers, plugins, rules, trusted projects |
 | Claude | `.claude/CLAUDE.md`, `.claude/settings*.json`, `.claude/hooks/*.sh`, `.claude/RTK.md` | `~/.claude/...` | Shared instructions, hooks, permissions, RTK guidance |
 | Shared AI skills | `.ai/skills/*` | `~/.codex/skills/*`, `~/.claude/skills/*` | `links.sh` replaces old skill dirs and symlinks each skill into both agents |
@@ -408,6 +409,20 @@ cd ~/Developer/dotfiles
 
 Run `./links.sh check` after changing `links.tsv`, shell config, agent config,
 or private symlink wiring.
+
+### GitHub Notification Sweep
+
+`bin/github-notification-sweep` defaults to dry-run. The LaunchAgent runs it
+with `--apply` every 15 minutes.
+
+```zsh
+bin/github-notification-sweep --limit 20
+cd ~/Developer/dotfiles
+./links.sh apply
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.dataders.github-notification-sweep.plist 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dataders.github-notification-sweep.plist
+launchctl kickstart -k gui/$(id -u)/com.dataders.github-notification-sweep
+```
 
 ### Prezto
 

--- a/bin/github-notification-sweep
+++ b/bin/github-notification-sweep
@@ -1,0 +1,162 @@
+#!/usr/bin/env -S /opt/homebrew/bin/uv run python3
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+
+
+DEFAULT_GH = "/opt/homebrew/bin/gh" if os.path.exists("/opt/homebrew/bin/gh") else "gh"
+
+
+class GhError(RuntimeError):
+    pass
+
+
+def gh_api(gh, *args, allow_404=False):
+    proc = subprocess.run(
+        [gh, "api", *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode == 0:
+        return proc.stdout
+    if allow_404 and "HTTP 404" in proc.stderr:
+        return ""
+    raise GhError(proc.stderr.strip() or f"gh api failed: {' '.join(args)}")
+
+
+def iter_notifications(gh):
+    output = gh_api(
+        gh,
+        "--paginate",
+        "/notifications?all=false&participating=false",
+        "--jq",
+        ".[] | @json",
+    )
+    for line in output.splitlines():
+        line = line.strip()
+        if line:
+            yield json.loads(line)
+
+
+def short_sha(value):
+    if not value:
+        return "unknown"
+    return value[:12]
+
+
+def pr_number(pr_ref):
+    if "number" in pr_ref:
+        return pr_ref["number"]
+    url = pr_ref.get("url", "")
+    if "/pulls/" in url:
+        return url.rsplit("/", 1)[-1]
+    return None
+
+
+def pull_request(gh, repo, number):
+    return json.loads(gh_api(gh, f"/repos/{repo}/pulls/{number}"))
+
+
+def branch_head_sha(gh, repo, branch):
+    quoted = urllib.parse.quote(branch, safe="")
+    output = gh_api(gh, f"/repos/{repo}/branches/{quoted}", allow_404=True)
+    if not output:
+        return None
+    return json.loads(output).get("commit", {}).get("sha")
+
+
+def stale_reason(gh, notification):
+    if notification.get("reason") != "ci_activity":
+        return None
+
+    repo = notification["repository"]["full_name"]
+    subject_url = notification.get("subject", {}).get("url")
+    if not subject_url:
+        return None
+
+    subject = json.loads(gh_api(gh, subject_url))
+    head_sha = subject.get("head_sha") or subject.get("head_commit", {}).get("id")
+    pull_requests = subject.get("pull_requests") or []
+
+    for pr_ref in pull_requests:
+        number = pr_number(pr_ref)
+        if not number:
+            continue
+        pr = pull_request(gh, repo, number)
+        if pr.get("merged"):
+            return f"PR #{number} merged"
+        if pr.get("state") == "closed":
+            return f"PR #{number} closed"
+        current_head = pr.get("head", {}).get("sha")
+        if head_sha and current_head and current_head != head_sha:
+            return f"PR #{number} moved from {short_sha(head_sha)} to {short_sha(current_head)}"
+
+    branch = subject.get("head_branch")
+    current_branch_head = branch_head_sha(gh, repo, branch) if branch and head_sha else None
+    if current_branch_head and current_branch_head != head_sha:
+        return f"branch {branch} moved from {short_sha(head_sha)} to {short_sha(current_branch_head)}"
+
+    return None
+
+
+def mark_done(gh, thread_id):
+    gh_api(gh, "--method", "DELETE", f"/notifications/threads/{thread_id}")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Archive stale GitHub Actions failure notifications from GitHub Inbox."
+    )
+    parser.add_argument("--apply", action="store_true", help="mark stale notifications done")
+    parser.add_argument("--repo", action="append", help="limit to owner/repo; repeatable")
+    parser.add_argument("--limit", type=int, help="stop after checking this many CI notifications")
+    parser.add_argument("--verbose", action="store_true", help="print kept CI notifications")
+    args = parser.parse_args(argv)
+
+    gh = os.environ.get("GH_NOTIFICATION_SWEEP_GH", DEFAULT_GH)
+    repos = set(args.repo or [])
+    checked = 0
+    stale = 0
+
+    for notification in iter_notifications(gh):
+        if notification.get("reason") != "ci_activity":
+            continue
+        repo = notification["repository"]["full_name"]
+        if repos and repo not in repos:
+            continue
+
+        checked += 1
+        if args.limit and checked > args.limit:
+            break
+
+        try:
+            reason = stale_reason(gh, notification)
+        except GhError as exc:
+            print(f"warning {notification.get('id')} {repo}: {exc}", file=sys.stderr)
+            continue
+
+        if not reason:
+            if args.verbose:
+                print(f"keep {notification.get('id')} {repo}: still current")
+            continue
+
+        stale += 1
+        action = "marked done" if args.apply else "would mark done"
+        title = notification.get("subject", {}).get("title", "")
+        print(f"{action} {notification['id']} {repo}: {reason} - {title}")
+        if args.apply:
+            mark_done(gh, notification["id"])
+
+    if stale == 0:
+        print(f"0 stale CI notifications ({checked} checked)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/links.tsv
+++ b/links.tsv
@@ -65,6 +65,7 @@ repo:wizard/providers.json	home:.dbt/wizard/providers.json	agents	public	Wizard 
 repo:.codex/rules/default.rules	home:.dbt/wizard/rules/default.rules	agents	public	Shared Codex/Wizard command-approval rules
 repo:AGENTS.md	home:.dbt/wizard/AGENTS.md	agents	public	Shared global agent instructions
 repo:Library/LaunchAgents/com.dataders.moonlander-keylog.plist	home:Library/LaunchAgents/com.dataders.moonlander-keylog.plist	moonlander	public	keylogger launchagent
+repo:Library/LaunchAgents/com.dataders.github-notification-sweep.plist	home:Library/LaunchAgents/com.dataders.github-notification-sweep.plist	github	public	GitHub stale CI notification sweeper launchagent
 repo:serena/projects/dbt-agent-skills/project.yml	developer:dbt-agent-skills/.serena/project.yml	agents	public	serena per-repo config
 repo:serena/projects/dbt-agent-skills/memories	developer:dbt-agent-skills/.serena/memories	agents	public	serena per-repo memories
 repo:serena/projects/dbt-clickhouse/project.yml	developer:dbt-clickhouse/.serena/project.yml	agents	public	serena per-repo config

--- a/tests/test_github_notification_sweep.py
+++ b/tests/test_github_notification_sweep.py
@@ -1,0 +1,159 @@
+import os
+import pathlib
+import plistlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "bin" / "github-notification-sweep"
+PLIST = ROOT / "Library" / "LaunchAgents" / "com.dataders.github-notification-sweep.plist"
+
+
+class GithubNotificationSweepTests(unittest.TestCase):
+    def fake_gh(self, tmpdir, responses):
+        fake = tmpdir / "gh"
+        log = tmpdir / "gh.log"
+        cases = "\n".join(
+            f"""\
+            if [[ "$args" == *{pattern!r}* ]]; then
+              cat <<'JSON'
+            {body}
+            JSON
+              exit 0
+            fi
+            """
+            for pattern, body in responses
+        )
+        fake.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            'args="$*"\n'
+            'printf "%s\\n" "$args" >> "$GH_FAKE_LOG"\n'
+            f"{textwrap.dedent(cases)}\n"
+            'echo "unexpected gh api call: $args" >&2\n'
+            "exit 9\n"
+        )
+        fake.chmod(0o755)
+        return fake, log
+
+    def run_sweep(self, fake, log, *args):
+        env = os.environ.copy()
+        env.update(
+            {
+                "GH_NOTIFICATION_SWEEP_GH": str(fake),
+                "GH_FAKE_LOG": str(log),
+            }
+        )
+        return subprocess.run(
+            [str(SCRIPT), *args],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_apply_marks_ci_notification_done_when_pr_head_moved(self):
+        with tempfile.TemporaryDirectory() as p:
+            tmp = pathlib.Path(p)
+            notification = (
+                '{"id":"123","reason":"ci_activity","repository":{"full_name":"o/r"},'
+                '"subject":{"title":"CI failed","type":"CheckSuite",'
+                '"url":"https://api.github.com/repos/o/r/check-suites/1"}}'
+            )
+            fake, log = self.fake_gh(
+                tmp,
+                [
+                    ("/notifications?all=false&participating=false", notification),
+                    (
+                        "https://api.github.com/repos/o/r/check-suites/1",
+                        '{"head_sha":"old","pull_requests":[{"number":7}]}',
+                    ),
+                    ("/repos/o/r/pulls/7", '{"number":7,"state":"open","merged":false,"head":{"sha":"new"}}'),
+                    ("/notifications/threads/123", "{}"),
+                ],
+            )
+
+            result = self.run_sweep(fake, log, "--apply")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("marked done 123 o/r", result.stdout)
+            self.assertIn("PR #7 moved from old to new", result.stdout)
+            self.assertIn("--method DELETE /notifications/threads/123", log.read_text())
+
+    def test_default_mode_is_dry_run_for_merged_pr(self):
+        with tempfile.TemporaryDirectory() as p:
+            tmp = pathlib.Path(p)
+            notification = (
+                '{"id":"456","reason":"ci_activity","repository":{"full_name":"o/r"},'
+                '"subject":{"title":"CI failed","type":"WorkflowRun",'
+                '"url":"https://api.github.com/repos/o/r/actions/runs/88"}}'
+            )
+            fake, log = self.fake_gh(
+                tmp,
+                [
+                    ("/notifications?all=false&participating=false", notification),
+                    (
+                        "https://api.github.com/repos/o/r/actions/runs/88",
+                        '{"head_sha":"abc","pull_requests":[{"number":8}]}',
+                    ),
+                    ("/repos/o/r/pulls/8", '{"number":8,"state":"closed","merged":true,"head":{"sha":"abc"}}'),
+                ],
+            )
+
+            result = self.run_sweep(fake, log)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("would mark done 456 o/r", result.stdout)
+            self.assertIn("PR #8 merged", result.stdout)
+            self.assertNotIn("--method DELETE", log.read_text())
+
+    def test_current_pr_head_is_kept(self):
+        with tempfile.TemporaryDirectory() as p:
+            tmp = pathlib.Path(p)
+            notification = (
+                '{"id":"789","reason":"ci_activity","repository":{"full_name":"o/r"},'
+                '"subject":{"title":"CI failed","type":"CheckSuite",'
+                '"url":"https://api.github.com/repos/o/r/check-suites/2"}}'
+            )
+            fake, log = self.fake_gh(
+                tmp,
+                [
+                    ("/notifications?all=false&participating=false", notification),
+                    (
+                        "https://api.github.com/repos/o/r/check-suites/2",
+                        '{"head_sha":"same","pull_requests":[{"number":9}]}',
+                    ),
+                    ("/repos/o/r/pulls/9", '{"number":9,"state":"open","merged":false,"head":{"sha":"same"}}'),
+                ],
+            )
+
+            result = self.run_sweep(fake, log)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("0 stale CI notifications", result.stdout)
+            self.assertNotIn("--method DELETE", log.read_text())
+
+    def test_launchagent_is_manifest_managed(self):
+        manifest = (ROOT / "links.tsv").read_text()
+
+        self.assertIn(
+            "repo:Library/LaunchAgents/com.dataders.github-notification-sweep.plist"
+            "\thome:Library/LaunchAgents/com.dataders.github-notification-sweep.plist",
+            manifest,
+        )
+
+        with PLIST.open("rb") as fh:
+            plist = plistlib.load(fh)
+
+        self.assertEqual(plist["Label"], "com.dataders.github-notification-sweep")
+        self.assertEqual(plist["ProgramArguments"][0], "/Users/dataders/Developer/dotfiles/bin/github-notification-sweep")
+        self.assertIn("StartInterval", plist)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a local GitHub notification sweeper that archives stale CI notifications
- install it through a LaunchAgent managed by links.tsv
- document dry-run/bootstrap commands and cover stale/current cases with tests

## Validation
- uv run python3 -m unittest discover tests
- plutil -lint Library/LaunchAgents/com.dataders.github-notification-sweep.plist
- git diff --check